### PR TITLE
Update buttonmap.xml, fix typo in topology.xml

### DIFF
--- a/game.libretro.fceumm/resources/buttonmap.xml
+++ b/game.libretro.fceumm/resources/buttonmap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <buttonmap version="2">
-	<controller id="game.controller.nes" type="RETRO_DEVICE_JOYPAD" subclass="0">
+	<controller id="game.controller.nes" type="RETRO_DEVICE_JOYPAD" subclass="1">
 		<feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
 		<feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
 		<feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
@@ -15,6 +15,10 @@
 	<controller id="game.controller.nes.arkanoid" type="RETRO_DEVICE_MOUSE" subclass="1"/>
 	<controller id="game.controller.famicom.arkanoid" type="RETRO_DEVICE_MOUSE" subclass="2"/>
 	<controller id="game.controller.famicom.oeka.kids" type="RETRO_DEVICE_MOUSE" subclass="3"/>
-	<controller id="game.controller.famicom.hyper.shot" type="RETRO_DEVICE_MOUSE" subclass="4"/>
+	<controller id="game.controller.famicom.shadow" type="RETRO_DEVICE_MOUSE" subclass="4"/>
+	-->
+	<controller id="game.controller.nes.four.score" type="RETRO_DEVICE_JOYPAD" subclass="2"/>
+	<!-- TODO
+	<controller id="game.controller.famicom.hyper.shot" type="RETRO_DEVICE_JOYPAD" subclass="3"/>
 	-->
 </buttonmap>

--- a/game.libretro.fceumm/resources/topology.xml
+++ b/game.libretro.fceumm/resources/topology.xml
@@ -4,7 +4,7 @@
     <accepts controller="game.controller.nes"/>
     <accepts controller="game.controller.nes.arkanoid"/>
     <accepts controller="game.controller.nes.zapper"/>
-    <accepts controller="game.controller.nes.four.square">
+    <accepts controller="game.controller.nes.four.score">
       <port id="1">
         <accepts controller="game.controller.nes"/>
       </port>

--- a/game.libretro.fceumm/resources/topology.xml
+++ b/game.libretro.fceumm/resources/topology.xml
@@ -2,8 +2,10 @@
 <logicaltopology playerlimit="4">
   <port id="1">
     <accepts controller="game.controller.nes"/>
+    <!-- TODO
     <accepts controller="game.controller.nes.arkanoid"/>
     <accepts controller="game.controller.nes.zapper"/>
+    -->
     <accepts controller="game.controller.nes.four.score">
       <port id="1">
         <accepts controller="game.controller.nes"/>
@@ -26,7 +28,9 @@
   </port>
   <port id="2">
     <accepts controller="game.controller.nes"/>
+    <!-- TODO
     <accepts controller="game.controller.nes.arkanoid"/>
     <accepts controller="game.controller.nes.zapper"/>
+    -->
   </port>
 </logicaltopology>


### PR DESCRIPTION
## Description

As title says, this PR updates buttonmap.xml from the latest libretro source and fixes a typo in topology.xml.

From FCEUmm source:

https://github.com/libretro/libretro-fceumm/blob/master/src/drivers/libretro/libretro.c

## How has this been tested?

Opened Port Dialog when playing NES game with fceumm:

![screenshot00001](https://user-images.githubusercontent.com/531482/219994851-ac416ee6-5242-42eb-a1fc-5eb284e44a3a.png)

Selected NES 4 Score:

![screenshot00002](https://user-images.githubusercontent.com/531482/219994871-76585545-158d-4fd3-9331-2f34f3725bb5.png)

Verified that only 4 controllers appeared in the UI:

![screenshot00003](https://user-images.githubusercontent.com/531482/219994910-e8fd86b5-577f-4b5d-b31e-e16849ae1a68.png)
